### PR TITLE
Honoring same homedir

### DIFF
--- a/cmd/profile/create.go
+++ b/cmd/profile/create.go
@@ -23,7 +23,6 @@ package profile
 import (
 	"fmt"
 	"os"
-	"os/user"
 	path "path/filepath"
 
 	common "github.com/MottainaiCI/mottainai-cli/common"
@@ -83,9 +82,8 @@ func newProfileCreateCommand(config *setting.Config) *cobra.Command {
 				f = v.ConfigFileUsed()
 			} else {
 
-				user, _ := user.Current()
 				f = fmt.Sprintf("%s/%s/%s.yml",
-					user.HomeDir,
+					common.GetHomeDir(),
 					common.MCLI_HOME_PATH,
 					common.MCLI_CONFIG_NAME)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,8 @@ func initConfig(config *setting.Config) {
 
 	// Set Config paths list
 	config.Viper.AddConfigPath(common.MCLI_LOCAL_PATH)
-	config.Viper.AddConfigPath(fmt.Sprintf("$HOME/%s", common.MCLI_HOME_PATH))
+	config.Viper.AddConfigPath(
+		fmt.Sprintf("%s/%s", common.GetHomeDir(), common.MCLI_HOME_PATH))
 
 	config.Viper.SetTypeByDefaultValue(true)
 }

--- a/common/tools.go
+++ b/common/tools.go
@@ -20,6 +20,8 @@ package common
 
 import (
 	"fmt"
+	"os"
+	"os/user"
 	"strings"
 
 	event "github.com/MottainaiCI/mottainai-server/pkg/event"
@@ -40,6 +42,15 @@ func CheckError(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func GetHomeDir() string {
+	u, _ := user.Current()
+	ans := u.HomeDir
+	if os.Getenv("HOME") != "" {
+		ans = os.Getenv("HOME")
+	}
+	return ans
 }
 
 func PrintResponse(resp event.APIResponse) {


### PR DESCRIPTION
This fix use of `mottainai-cli` if `$HOME` is not the user homedir returned by golang API.